### PR TITLE
Auto Set Up Routines

### DIFF
--- a/PSGallery/Public/Set-EUCMonitoring.ps1
+++ b/PSGallery/Public/Set-EUCMonitoring.ps1
@@ -24,9 +24,16 @@
 
     Param
     (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$MonitoringPath
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$MonitoringPath
     )
 
+    if($MonitoringPath -eq $null){
+        $MonitoringPath = "C:\Monitoring"
+    }
+
+    New-Item -Path "HKLM:\Software" -Name "EUCMonitoring" -Force
+    New-ItemProperty -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation" -Value $MonitoringPath
+    
     # Get old Verbose Preference and storeit, change Verbose Preference to Continue
     $OldVerbosePreference = $VerbosePreference
     $VerbosePreference = "Continue"

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -19,6 +19,7 @@
     David Brett             1.1             20/02/2018          Added Error Checking and Single Ring output
     James Kindon            1.2             15/03/2018          Added Provisioning Server Module
     James Kindon            1.3             17/03/2018          Added WEM, UPS and FAS Modules
+    David Brett             1.4             19/03/2018          Added the ability to pull the files location from the registry
 .PARAMETER RootDirectory
     RootDirectory
 .EXAMPLE
@@ -27,8 +28,12 @@
 
     Param
     (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$RootDirectory
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$RootDirectory
     )
+
+if($RootDirectory -eq $null) {
+    $RootDirectory = Get-ItemPropertyValue -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation"
+}
 
 # Get old Verbose Preference and storeit, change Verbose Preference to Continue
 $OldVerbosePreference = $VerbosePreference


### PR DESCRIPTION
Added the ability to get a default reg key with the monitoring files path and allow the set-eucmonitoring to be run without a switch, then added a get-itempropertyvalue switch to the start-xdmonitor function to pull this value from the registry