### PR TITLE
Changes to public functions and parameters

### DIFF
--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -31,7 +31,7 @@ function New-HtmlReport {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$InfrastructureComponents,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$InfrastructureList,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$WorkerList,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$RootDirectory
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CSSFile
     )
 
     # Generate HTML Output File
@@ -47,7 +47,7 @@ function New-HtmlReport {
 
     # Write CSS Style
     "<style>" | Out-File $HTMLOutputFileFull -Append
-    $CSSData = Get-Content "$RootDirectory\euc-monitor.css"
+    $CSSData = Get-Content $CSSFile
     $CSSData | Out-File $HTMLOutputFileFull -Append
     "</style>" | Out-File $HTMLOutputFileFull -Append
 

--- a/PSGallery/Private/Test-CC.ps1
+++ b/PSGallery/Private/Test-CC.ps1
@@ -1,0 +1,121 @@
+function Test-CC {
+    <#   
+.SYNOPSIS   
+    Tests Citrix Cloud Connector Servers
+.DESCRIPTION 
+    Tests Citrix Cloud Connector Servers
+    Currently Testing
+        Cloud Connector Server Availability
+        Cloud Connector Port Connectivity
+        All Services passed into the module     
+.PARAMETER CCServers 
+    Comma Delimited List of Cloud Connector Servers to check
+.PARAMETER CCPortString 
+    TCP Port to use for Cloud Connector Connectivity Tests
+.PARAMETER CCServices 
+    Cloud Connector Services to check
+.PARAMETER ErrorFile 
+    Infrastructure Error File to Log To
+.PARAMETER OutputFile 
+    Infrastructure OutputFile   
+.NOTES
+    Current Version:        1.0
+    Creation Date:          19/03/2018
+.CHANGE CONTROL
+    Name                    Version         Date                Change Detail
+    David Wilkinson         1.0             19/03/2018          Function Creation
+.EXAMPLE
+    None Required
+#> 
+
+    Param
+    (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CCServers,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CCPortString,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CCServices,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$ErrorFile,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$OutputFile
+
+    )
+
+    # Initialize Arrays and Variables
+    $CCServerUp = 0
+    $CCServerDown = 0
+    Write-Verbose "Variables and Arrays Initalized"
+
+    # Get Cloud Connector Server Comma Delimited List 
+    $CCServers = $CCServers.Split(",")
+    $CCServices = $CCServices.Split(",")
+    Write-Verbose "Read in Cloud Connector Details"
+    Write-Verbose "Cloud Connector Servers: $CCServers"
+    Write-Verbose "Cloud Connector Ports: $CCPortString" 
+    Write-Verbose "Cloud Connector Services: $CCServices"
+
+    foreach ($CCServer in $CCServers) {
+
+        # Check that the Cloud Connector Server is up
+        if ((Connect-Server $CCServer) -eq "Successful") {
+			
+            # Server is up and responding to ping
+            Write-Verbose "$CCServer is online and responding to ping" 
+
+            # Check the Cloud Connector Server Port
+            if ((Test-NetConnection $CCServer $CCPortString).open -eq "True") {
+
+                # Cloud Connector incoming port is up and running
+                Write-Verbose "$CCServer Incoming Port is up: Port - $CCPortString"
+
+                # Check all critical services are running on the Cloud Connector Server
+                # Initalize Pre loop variables and set Clean Run Services to Yes
+                $ServicesUp = "Yes"
+                $ServiceError = ""
+
+                # Check Each Service for a Running State
+                foreach ($Service in $CCServices) {
+                    $CurrentServiceStatus = Check-Service $CCServer $Service
+                    If ($CurrentServiceStatus -ne "Running") {
+                        # If the Service is not running set ServicesUp to No and Append The Service with an error to the error description
+                        if ($ServiceError -eq "") {
+                            $ServiceError = $Service
+                        }
+                        else {
+                            $ServiceError = $ServiceError + ", " + $Service
+                        }
+                        $ServicesUp = "no"
+                    }
+                }
+
+                # Check for ALL services running, if so mark Cloud Connector Server as UP, if not Mark as down and increment down count
+                if ($ServicesUp -eq "Yes") {
+                    # The Cloud Connector Server and all services tested successfully - mark as UP
+                    Write-Verbose "$CCServer is up and all Services are running"
+                    $CCServerUp++
+                }
+                else {
+                    # There was an error with one or more of the services
+                    Write-Verbose "$CCServer Service error - $ServiceError - is degraded or stopped."
+                    "$CCServer Service error - $ServiceError - is degraded or stopped." | Out-File $ErrorFile -Append
+                    $CCServerDown++
+                }
+                
+            }
+            else {
+                # Cloud Connector incoming Port is down - mark down, error log and increment down count
+                Write-Verbose "$CCServer incoming Port is down - Port - $CCPortString"
+                "$CCServer Incoming Port is down - Port - $CCPortString" | Out-File $ErrorFile -Append
+                $CCServerDown++
+            }
+
+        }
+        else {
+            # Cloud Connector Server is down - not responding to ping
+            Write-Verbose "$CCServer is down" 
+            "$CCServer is down"  | Out-File $ErrorFile -Append
+            $CCServerDown++
+        }
+    }
+
+    # Write Data to Output File
+    Write-Verbose "Writing Cloud Connector Server Data to output file"
+    "CCServer,$CCServerUp,$CCServerDown" | Out-File $OutputFile
+}

--- a/PSGallery/Public/Set-EUCMonitoring.ps1
+++ b/PSGallery/Public/Set-EUCMonitoring.ps1
@@ -17,7 +17,7 @@
         Name                    Version         Date                Change Detail
         David Brett             1.0             19/03/2018          Script Creation
     .PARAMETER MonitoringPath
-        MonitoringPath
+        Folder path to download files needed for monitoring process
     .EXAMPLE
         None Required
     #>

--- a/PSGallery/Public/Set-EUCMonitoring.ps1
+++ b/PSGallery/Public/Set-EUCMonitoring.ps1
@@ -1,59 +1,57 @@
 ﻿function Set-EUCMonitoring {
-<#
-.SYNOPSIS
-    Sets up the EUC Monitoring Platform
-.DESCRIPTION
-    Sets up the EUC Monitoring Platform
-.PARAMETER
-    None
-.INPUTS
-    None
-.OUTPUTS
-    None
-.NOTES
-    Current Version:        1.0
-    Creation Date:          19/03/2018
-.CHANGE CONTROL
-    Name                    Version         Date                Change Detail
-    David Brett             1.0             19/03/2018          Script Creation
-.PARAMETER MonitoringPath
-    MonitoringPath
-.EXAMPLE
-    None Required
-#>
-
-    Param
-    (
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$MonitoringPath
-    )
-
-    if($MonitoringPath -eq $null){
-        $MonitoringPath = "C:\Monitoring"
-    }
-
-    New-Item -Path "HKLM:\Software" -Name "EUCMonitoring" -Force
-    New-ItemProperty -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation" -Value $MonitoringPath
+    <#
+    .SYNOPSIS
+        Sets up the EUC Monitoring Platform
+    .DESCRIPTION
+        Sets up the EUC Monitoring Platform
+    .PARAMETER
+        None
+    .INPUTS
+        None
+    .OUTPUTS
+        None
+    .NOTES
+        Current Version:        1.0
+        Creation Date:          19/03/2018
+    .CHANGE CONTROL
+        Name                    Version         Date                Change Detail
+        David Brett             1.0             19/03/2018          Script Creation
+    .PARAMETER MonitoringPath
+        MonitoringPath
+    .EXAMPLE
+        None Required
+    #>
+        [cmdletbinding()]
+        Param
+        (
+            [parameter(Mandatory = $false, ValueFromPipeline = $true)]$MonitoringPath = (get-location) #gets current directory location
+        )
     
-    # Get old Verbose Preference and storeit, change Verbose Preference to Continue
-    $OldVerbosePreference = $VerbosePreference
-    $VerbosePreference = "Continue"
-
-    if(test-path $MonitoringPath){
-        Write-Verbose "Monitoring Directory $MonitoringPath Already Present"
-    } else {
-        New-Item $MonitoringPath -ItemType Directory
-        Write-Verbose "EUC Monitoring Directory Created $MonitoringPath"
+    
+        #New-Item -Path "HKLM:\Software" -Name "EUCMonitoring" -Force
+        #New-ItemProperty -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation" -Value $MonitoringPat
+    
+    
+        if(test-path $MonitoringPath){
+            Write-Verbose "Monitoring Directory $MonitoringPath Already Present"
+        } else {
+            New-Item $MonitoringPath -ItemType Directory
+            Write-Verbose "EUC Monitoring Directory Created $MonitoringPath"
+        }
+    
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        #Files needed to check and downloads
+        $filesneeded = @("euc-monitor.css","euc-monitoring.json.template","euc-monitoring-json-ref.txt")
+        
+        foreach ($needed in $filesneeded)
+        {
+            Write-Verbose "Checking for $needed"
+            if(test-path "$MonitoringPath\$needed"){
+                Write-Verbose "$needed already Present"
+            } else {
+                Write-Verbose "Pulling $needed"
+                Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/eucmonitoring/master/Package/$needed" -OutFile "$MonitoringPath\$needed"
+            }
+        }
+    
     }
-
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Write-Verbose "Pulling euc-monitor.css"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/dbretty/eucmonitoring/master/Package/euc-monitor.css -OutFile $MonitoringPath\euc-monitor.css
-    Write-Verbose "Pulling euc-monitoring-json-ref.txt"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/dbretty/eucmonitoring/master/Package/euc-monitoring-json-ref.txt -OutFile $MonitoringPath\euc-monitoring-json-ref.txt
-    Write-Verbose "Pulling euc-monitoring.json.template"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/dbretty/eucmonitoring/master/Package/euc-monitoring.json.template -OutFile $MonitoringPath\euc-monitoring.json.template
-
-    # Set the old Verbose Preference back to original value
-    $VerbosePreference = $OldVerbosePreference
-
-}

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -20,8 +20,12 @@
     James Kindon            1.2             15/03/2018          Added Provisioning Server Module
     James Kindon            1.3             17/03/2018          Added WEM, UPS and FAS Modules
     David Brett             1.4             19/03/2018          Added the ability to pull the files location from the registry
-.PARAMETER RootDirectory
-    RootDirectory
+.PARAMETER JsonFile
+    Path to JSON settings file
+.PARAMETER CSSFile
+    Path to CSS file for HTML output
+.PARAMETER LogFile
+    Path to log output file
 .EXAMPLE
     None Required
 #>

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -202,8 +202,8 @@ if (test-path $MyConfigFileLocation) {
     $ctxsnap = get-pssnapin citrix*
 
     if ($ctxsnap -eq $null) {
-        Write-Verbose "XenDesktop Powershell Snapin Load Failed - No XenDesktop Brokering SDK Found"
-        Write-Verbose "Cannot Load XenDesktop Powershell SDK"
+        Write-error "XenDesktop Powershell Snapin Load Failed - No XenDesktop Brokering SDK Found"
+        Write-error "Cannot Load XenDesktop Powershell SDK"
         Exit
     }
     else {
@@ -222,7 +222,7 @@ if (test-path $MyConfigFileLocation) {
             Write-Verbose "Cannot connect to any of the configured brokers - quitting"
             # Remove Global Functions File
             remove-module xendesktop-monitor-global
-            Write-Warning"Cannot Connect to XenDesktop Brokers $XDBrokerPrimary or $XDBrokerFailover"
+            Write-error "Cannot Connect to XenDesktop Brokers $XDBrokerPrimary or $XDBrokerFailover"
             Exit
         }
     }

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -25,25 +25,24 @@
 .EXAMPLE
     None Required
 #>
-
+[cmdletbinding()]
     Param
     (
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$RootDirectory
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$RootDirectory=(get-location),
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$LogLocation = "${env:SystemRoot}" + "\Temp\euc-monitoring.log",
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$JsonFile = "$rootdirectory\euc-monitoring.json"
     )
 
-if($RootDirectory -eq $null) {
-    $RootDirectory = Get-ItemPropertyValue -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation"
-}
+#if($RootDirectory -eq $null) {
+#    $RootDirectory = Get-ItemPropertyValue -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation"
+#}
 
-# Get old Verbose Preference and storeit, change Verbose Preference to Continue
-$OldVerbosePreference = $VerbosePreference
-$VerbosePreference = "Continue"
 
 # Set Log file location
-$Log = "${env:SystemRoot}" + "\Temp\euc-monitoring.log"
+$Log = $LogLocation
     
 # Read in the JSON File
-$MyConfigFileLocation = ("$RootDirectory\euc-monitoring.json")
+$MyConfigFileLocation = $jsonfile
 
 if (test-path $MyConfigFileLocation) {
 
@@ -169,7 +168,7 @@ if (test-path $MyConfigFileLocation) {
             New-Item -ItemType directory -Path $OutputLocation -ErrorAction Stop
         }
         Catch {
-            Write-Verbose "Could Not Create Output Directory $OutputLocation Quitting"
+            Write-Error "Could Not Create Output Directory $OutputLocation Quitting"
             Exit
         } 
     }
@@ -204,8 +203,6 @@ if (test-path $MyConfigFileLocation) {
 
     if ($ctxsnap -eq $null) {
         Write-Verbose "XenDesktop Powershell Snapin Load Failed - No XenDesktop Brokering SDK Found"
-        # Remove Global Functions File
-        remove-module xendesktop-monitor-global
         Write-Verbose "Cannot Load XenDesktop Powershell SDK"
         Exit
     }
@@ -225,7 +222,7 @@ if (test-path $MyConfigFileLocation) {
             Write-Verbose "Cannot connect to any of the configured brokers - quitting"
             # Remove Global Functions File
             remove-module xendesktop-monitor-global
-            Write-Verbose "Cannot Connect to XenDesktop Brokers $XDBrokerPrimary or $XDBrokerFailover"
+            Write-Warning"Cannot Connect to XenDesktop Brokers $XDBrokerPrimary or $XDBrokerFailover"
             Exit
         }
     }
@@ -286,7 +283,7 @@ if (test-path $MyConfigFileLocation) {
         "Total User Base,$TotalConnectedUsers,$TotalUsersDisconnected" | Out-File $HTMLDataFullPath -Append
 
         # Work out the number of Delivery Groups in Maintenance Mode and write them back to the HTML Data File
-        $DGFullCount = ($DeliveryGroups | Measure).Count
+        $DGFullCount = ($DeliveryGroups | Measure-Object).Count
         $DGMaintenanceCount = ($DeliveryGroups | Where-Object {$_.InMaintenanceMode -match "True"} | Measure).Count
         $DGNonMaintenanceCount = ($DeliveryGroups | Where-Object {$_.InMaintenanceMode -match "False"} | Measure).Count
         Write-Verbose "Total Number of Delivery Groups: $DGFullCount"
@@ -303,7 +300,7 @@ if (test-path $MyConfigFileLocation) {
         else {
             $BrokerMachines = Get-BrokerMachine | Where-Object {$_.SessionSupport -eq "SingleSession"} | Select HostedMachineName, DesktopKind, InMaintenanceMode, PowerState, RegistrationState, SessionSupport, WindowsConnectionSetting, ZoneName
         }
-        $BMFullCount = ($BrokerMachines | Measure).Count
+        $BMFullCount = ($BrokerMachines | Measure-object).Count
         $BMMaintenanceCount = ($BrokerMachines | Where-Object {($_.InMaintenanceMode -match "True" -and $_.PowerState -match "On")} | Measure).Count
         $BMOffCount = ($BrokerMachines | Where-Object {($_.PowerState -match "Off")} | Measure).Count
         $BMOnCount = ($BrokerMachines | Where-Object {($_.PowerState -match "On")} | Measure).Count
@@ -798,17 +795,14 @@ if (test-path $MyConfigFileLocation) {
 
     # Stop the timer and display the output
     $EndTime = (Get-Date)
-    Write-Verbose "Elapsed Time: $(($EndTime-$StartTime).TotalSeconds) Seconds" -Verbose
-    Write-Verbose "Elapsed Time: $(($EndTime-$StartTime).TotalMinutes) Minutes" -Verbose
+    Write-Verbose "Elapsed Time: $(($EndTime-$StartTime).TotalSeconds) Seconds"
+    Write-Verbose "Elapsed Time: $(($EndTime-$StartTime).TotalMinutes) Minutes"
 
     # Stop the transcript
     Stop-Transcript
 }
 else {
-    write-verbose "Path not found to json"
+    write-error "Path not found to json. Run Set-EUCMonitoring to get started."
 }
-
-# Set the old Verbose Preference back to original value
-$VerbosePreference = $OldVerbosePreference
 
 }

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -27,19 +27,15 @@
 #>
 [cmdletbinding()]
     Param
-    (
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$RootDirectory=(get-location),
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$LogLocation = "${env:SystemRoot}" + "\Temp\euc-monitoring.log",
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$JsonFile = "$rootdirectory\euc-monitoring.json"
+    (        
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$JsonFile = ("$(get-location)\euc-monitor.json"),
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$CSSFile = ("$(get-location)\euc-monitor.css"),
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]$LogFile = ("$(get-location)\euc-monitoring.log")
     )
 
 #if($RootDirectory -eq $null) {
 #    $RootDirectory = Get-ItemPropertyValue -Path "HKLM:\Software\EUCMonitoring" -Name "FileLocation"
 #}
-
-
-# Set Log file location
-$Log = $LogLocation
     
 # Read in the JSON File
 $MyConfigFileLocation = $jsonfile
@@ -52,7 +48,7 @@ if (test-path $MyConfigFileLocation) {
     $MyJSONConfigFile = Get-Content -Raw -Path $MyConfigFileLocation | ConvertFrom-Json
     
     # Start the Transcript
-    Start-Transcript $Log
+    Start-Transcript $LogFile
     
     # Read in the JSON Data
 
@@ -791,7 +787,7 @@ if (test-path $MyConfigFileLocation) {
     }
   
     # Build the HTML output file
-    New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $RootDirectory
+    New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile
 
     # Stop the timer and display the output
     $EndTime = (Get-Date)

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@ Find-Module EUCMonitoring
 4. Next run the following command pointing to a directory that you want the EUC Monitoring setting files and output HTML to reside.
 
 ```text
-Set-EUCMonitoring C:\Monitoring
+Set-EUCMonitoring C:\Monitoring -verbose
 ```
 
 5. Once this is done go to that directory and rename the **euc-monitoring.json.template** file to **euc-monitoring.json**
@@ -45,7 +45,12 @@ Set-EUCMonitoring C:\Monitoring
 7. Finally run the following command pointing to the directory that holds all the EUC Monitoring Scripts
 
 ```text
-Start-XDMonitor C:\Monitoring
+cd C:\Monitoring
+Start-XDMonitor
+```
+OR
+```text
+Start-XDMonitor -JsonFile ".\mysettings.json" -LogFile ".\mylog.txt" -CSSFile ".\euc-monitor.css" -Verbose 
 ```
 
 8. Open up your new dashboard HTML file from the location you specified in your json for web data output

--- a/README.MD
+++ b/README.MD
@@ -42,7 +42,7 @@ Set-EUCMonitoring C:\Monitoring -verbose
 
 5. Once this is done go to that directory and rename the **euc-monitoring.json.template** file to **euc-monitoring.json**
 6. Edit the json file to reflect your environment
-7. Finally run the following command pointing to the directory that holds all the EUC Monitoring Scripts
+7. Finally run the following command pointing to the directory that holds the needed files
 
 ```text
 cd C:\Monitoring


### PR DESCRIPTION
* Flipped public functions to advanced with `[cmdletbinding()]` and removed default verbose output.  Verbose can be seen with `-verbose` switch for the two commands.
## Start-XDMonitor
  * added some parameters to allow file flexibility 
    * Logging file path. Defaults to current directory euc-monitoring.log (LogFile)
    * Json file path. Defaults to current directory euc-monitor.json (JsonFile)
    * CSS file path.  Defaults to current directory euc-monitor.css (CSSFile)
  * Changed some verbose output to errors
  * Removed registry read for location
## Set-EUCMonitoring
  * Granular checking for file testing and download.
  * Removed registry tattooing for now (needs admin rights)
  * MonitoringPath parameter uses current directory to download files by default
## New-HtmlReport.ps1
  * Changed rootdirectory parameter to CSSFile.
