### PR TITLE
Add autorefresh support to the dashboard

### DIFF
--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -31,7 +31,8 @@ function New-HtmlReport {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$InfrastructureComponents,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$InfrastructureList,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$WorkerList,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CSSFile
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CSSFile,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$RefreshDuration
     )
 
     # Generate HTML Output File
@@ -50,7 +51,12 @@ function New-HtmlReport {
     $CSSData = Get-Content $CSSFile
     $CSSData | Out-File $HTMLOutputFileFull -Append
     "</style>" | Out-File $HTMLOutputFileFull -Append
-
+    
+    # Add automatic refresh in seconds. 
+    if ( $RefreshDuration -ne 0 ) {
+        '<meta http-equiv="refresh" content="' + $RefreshDuration + '" >' | Out-File $HTMLOutputFileFull -Append
+    }
+    
     "</head>" | Out-File $HTMLOutputFileFull -Append
     "<body>" | Out-File $HTMLOutputFileFull -Append
 

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -63,81 +63,10 @@
         $WorkLoads = $MyJSONConfigFile.Citrix.Global.workloads
         $ControlUp = $MyJSONConfigFile.Citrix.Global.controlup
   
-<<<<<<< HEAD
-    # Web Data
-    $HTMLData = $MyJSONConfigFile.WebData.htmldatafile
-    $HTMLOutput = $MyJSONConfigFile.WebData.htmloutputfile
-    $RefreshDuration = $MyJSONConfigFile.WebData.refreshduration     
-    $ServerErrorFile = $MyJSONConfigFile.WebData.servererrorfile
-    $DesktopErrorFile = $MyJSONConfigFile.WebData.desktoperrorfile
-    $InfraErrorFile = $MyJSONConfigFile.WebData.infraerrorfile
-    $UpColour = $MyJSONConfigFile.WebData.UpColour
-    $DownColour = $MyJSONConfigFile.WebData.DownColour
-    $OutputLocation = $MyJSONConfigFile.WebData.outputlocation
-    $WorkerDonutStroke = $MyJSONConfigFile.WebData.WorkerDonutStroke
-    $WorkerDonutSize = $MyJSONConfigFile.WebData.workerdonutsize
-    $InfraDonutStroke = $MyJSONConfigFile.WebData.InfraDonutStroke
-    $InfraDonutSize = $MyJSONConfigFile.WebData.infradonutsize
-    $WorkerComponents = 1
-    $InfrastructureComponents = 0
-    $InfrastructureList = @()
-
-    # XenServer Data
-    $TestXenServer = $MyJSONConfigFile.Citrix.xenserver.test
-    $PoolMasters = $MyJSONConfigFile.Citrix.xenserver.poolmasters
-    $ConnectionPort = $MyJSONConfigFile.Citrix.xenserver.poolmasterport
-    $XenUserName = $MyJSONConfigFile.Citrix.xenserver.username
-    $XenPassword = $MyJSONConfigFile.Citrix.xenserver.password
-
-    # StoreFront Data
-    $TestStoreFront = $MyJSONConfigFile.Citrix.storefront.test
-    $StoreFrontServers = $MyJSONConfigFile.Citrix.storefront.storefrontservers
-    $StoreFrontPort = $MyJSONConfigFile.Citrix.storefront.storefrontport
-    $StoreFrontPath = $MyJSONConfigFile.Citrix.storefront.storefrontpath
-    $StoreFrontProtocol = $MyJSONConfigFile.Citrix.storefront.protocol
-
-    # Licensing Data
-    $TestLicensing = $MyJSONConfigFile.Citrix.licensing.test
-    $LicenseServers = $MyJSONConfigFile.Citrix.licensing.licenseservers
-    $VendorDaemonPort = $MyJSONConfigFile.Citrix.licensing.vendordaemonport
-    $LicensePort = $MyJSONConfigFile.Citrix.licensing.licenseport
-    $WebAdminPort = $MyJSONConfigFile.Citrix.licensing.webadminport
-    $SimpleLicensePort = $MyJSONConfigFile.Citrix.licensing.simplelicenseserviceport
-
-    # Director Data
-    $TestDirector = $MyJSONConfigFile.Citrix.director.test
-    $DirectorServers = $MyJSONConfigFile.Citrix.director.directorervers
-    $DirectorPort = $MyJSONConfigFile.Citrix.director.directorport
-    $DirectorPath = $MyJSONConfigFile.Citrix.director.directorpath
-    $DirectorProtocol = $MyJSONConfigFile.Citrix.director.protocol
-
-    # Controller Data
-    $TestController = $MyJSONConfigFile.Citrix.controllers.test
-    $ControllerServers = $MyJSONConfigFile.Citrix.controllers.controllerservers
-    $ControllerPort = $MyJSONConfigFile.Citrix.controllers.controllerport
-    $ControllerServices = $MyJSONConfigFile.Citrix.controllers.controllerservices
-
-    # Provisioning Server Data
-    $TestProvisioningServer = $MyJSONConfigFile.Citrix.ProvisioningServers.test
-    $ProvisioningServerFarm = $MyJSONConfigFile.Citrix.ProvisioningServers.ProvisioningServerFarm
-    $ProvisioningServerSite = $MyJSONConfigFile.Citrix.ProvisioningServers.ProvisioningServerSite
-    $ProvisioningServers = $MyJSONConfigFile.Citrix.ProvisioningServers.ProvisioningServers
-    $ProvisioningServerPort = $MyJSONConfigFile.Citrix.ProvisioningServers.ProvisioningServerport
-    $ProvisioningServerServices = $MyJSONConfigFile.Citrix.ProvisioningServers.ProvisioningServerServices
-
-    # NetScaler Data
-    $TestNetScaler = $MyJSONConfigFile.Citrix.netscalers.test
-    $NetScalers = $MyJSONConfigFile.Citrix.netscalers.netscalers
-    $NetScalerUserName = $MyJSONConfigFile.Citrix.netscalers.netscalerusername
-    $NetScalerPassword = $MyJSONConfigFile.Citrix.netscalers.netscalerpassword
-
-    # NetScaler Gateway Data
-    $TestNetScalerGateway = $MyJSONConfigFile.Citrix.netscalergateway.test
-    $NetScalerHostingGateway = $MyJSONConfigFile.Citrix.netscalergateway.netscalerhostinggateway
-=======
         # Web Data
         $HTMLData = $MyJSONConfigFile.WebData.htmldatafile
         $HTMLOutput = $MyJSONConfigFile.WebData.htmloutputfile
+        $RefreshDuration = $MyJSONConfigFile.WebData.refreshduration
         $ServerErrorFile = $MyJSONConfigFile.WebData.servererrorfile
         $DesktopErrorFile = $MyJSONConfigFile.WebData.desktoperrorfile
         $InfraErrorFile = $MyJSONConfigFile.WebData.infraerrorfile
@@ -207,7 +136,6 @@
         # NetScaler Gateway Data
         $TestNetScalerGateway = $MyJSONConfigFile.Citrix.netscalergateway.test
         $NetScalerHostingGateway = $MyJSONConfigFile.Citrix.netscalergateway.netscalerhostinggateway
->>>>>>> upstream/master
     
         # Citrix WEM Data
         $TestWEM = $MyJSONConfigFile.Citrix.WEM.test
@@ -867,13 +795,8 @@
             Write-Verbose "Deleted Donut Data File $FASServerData"
         }
   
-<<<<<<< HEAD
-    # Build the HTML output file
-    New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile $RefreshDuration
-=======
         # Build the HTML output file
-        New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile
->>>>>>> upstream/master
+        New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile $RefreshDuration
 
         # Stop the timer and display the output
         $EndTime = (Get-Date)

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -65,6 +65,7 @@ if (test-path $MyConfigFileLocation) {
     # Web Data
     $HTMLData = $MyJSONConfigFile.WebData.htmldatafile
     $HTMLOutput = $MyJSONConfigFile.WebData.htmloutputfile
+    $RefreshDuration = $MyJSONConfigFile.WebData.refreshduration     
     $ServerErrorFile = $MyJSONConfigFile.WebData.servererrorfile
     $DesktopErrorFile = $MyJSONConfigFile.WebData.desktoperrorfile
     $InfraErrorFile = $MyJSONConfigFile.WebData.infraerrorfile
@@ -791,7 +792,7 @@ if (test-path $MyConfigFileLocation) {
     }
   
     # Build the HTML output file
-    New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile
+    New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile $RefreshDuration
 
     # Stop the timer and display the output
     $EndTime = (Get-Date)

--- a/Package/euc-monitoring-json-ref.txt
+++ b/Package/euc-monitoring-json-ref.txt
@@ -9,6 +9,7 @@
         "outputlocation": "c:\\monitoring", - Output Directory
         "htmldatafile": "htmldata.txt", - HTML Data File - Can Leave as Default
         "htmloutputfile": "index.html", - HTML Output File - Can Leave as Default
+        "refreshduration": 300, - HTML Automatic page refresh in seconds, 0 for disabled
         "servererrorfile": "server-errors.txt", - Server Error File - Can Leave as Default
         "desktoperrorfile": "desktop-errors.txt", - Desktop Error File - Can Leave as Default
         "UpColour": "rgba(221, 70, 70, 0.9)", - Color for "UP" Servers on the output graph

--- a/Package/euc-monitoring.json.template
+++ b/Package/euc-monitoring.json.template
@@ -3,6 +3,7 @@
         "outputlocation": "c:\\webdata",
         "htmldatafile": "htmldata.txt",
         "htmloutputfile": "index.html",
+        "refreshduration": 0,
         "servererrorfile": "server-errors.txt",
         "desktoperrorfile": "desktop-errors.txt",
         "UpColour": "rgba(221, 70, 70, 0.9)",


### PR DESCRIPTION
Configured in the json file, in the webdata section, this will allow for those that want to eventually create a scheduled task to keep the page current will also have the browser check for updates regularly.  Uses meta tag instead of javascript, configured in seconds between duration.   