### PR TITLE
Adding support for Citrix Environmental checks

### DIFF
--- a/PSGallery/Private/Test-EnvChecksXD.ps1
+++ b/PSGallery/Private/Test-EnvChecksXD.ps1
@@ -1,0 +1,179 @@
+function Test-EnvChecks-XD.ps1 {
+    <#   
+.SYNOPSIS   
+    Checks the Status of the Environmental Tests Passed In
+.DESCRIPTION 
+    Checks the Status of the Environmental Tests Passed In
+.PARAMETER Broker
+    Current Broker
+.PARAMETER ErrorFile 
+    Infrastructure Error File to Log To
+.PARAMETER OutputFile 
+    Infrastructure OutputFile
+.PARAMETER DDCcheck 
+    "yes" test Delivery Controllers Environmental Checks. All other inputs to skip.
+.PARAMETER DeliveryGroupCheck
+    "yes" to test Delivery Groups Environmental Checks. All others to skip. 
+.PARAMETER CatalogCheck
+    "yes" to test Catalogs Environmental Checks. All others to skip.
+.PARAMETER HypervisorCheck
+    "yes" to test Hypervisor and Associated Resources Environmental Checks. All other inputs to skip.
+.NOTES
+    Current Version:        1.0
+    Creation Date:          22/02/2018
+.CHANGE CONTROL
+    Name                    Version         Date                Change Detail
+    Adam Yarborough         1.0             21/03/2018          Function Creation
+
+.EXAMPLE
+    None Required
+#>
+    Param(
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$AdminAddress,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$ErrorFile,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$OutputFile,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DDCcheck,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DeliveryGroupCheck,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$CatalogCheck,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$HypervisorCheck
+    )
+
+    if ($DDCcheck -eq "yes") {
+        Write-Verbose "Delivery Controllers Env Check started"
+        $EnvCheckUp = 0
+        $EnvCheckDown = 0
+        $XDDeliveryControllers = Get-BrokerController -AdminAddress $AdminAddress
+
+        Write-Verbose "Variables and Arrays Initialized"
+
+        foreach ( $DeliveryController in $XDDeliveryControllers) {
+            $Status = "Passed"
+            Write-Verbose "Initialize Test Variables"
+            Write-Verbose "Testing $($DeliveryController.MachineName)"
+            $TestTarget = New-EnvTestDiscoveryTargetDefinition -AdminAddress $AdminAddress -TargetIdType "Infrastructure" -TestSuiteId "Infrastructure" -TargetId $DeliveryController.Uuid
+            $TestResults = Start-EnvTestTask -AdminAddress $AdminAddress -InputObject $TestTarget -RunAsynchronously
+            foreach ( $Result in $TestResults.TestResults ) {
+                foreach ( $Component in $Result.TestComponents ) {
+                    Write-Verbose "$($DeliveryController.MachineName) - $($Component.TestID) - $($Component.TestComponentStatus)"
+                    if ( ($Component.TestComponentStatus -ne "CompletePassed") -and ($Component.TestComponentStatus -ne "NotRun") ) {
+                        "$($DeliveryController.MachineName) - $($Component.TestID) - $($Component.TestComponentStatus)" | Out-File $ErrorFile -append
+                        $Status = "Component Failure"
+                    }
+                } 
+            }
+            if ( $Status -eq "Passed" ) { $EnvCheckUp++ }
+            else { $EnvCheckDown++ }
+        }
+    }
+
+    if ($DeliveryGroupCheck -eq "yes") {
+        Write-Verbose "Delivery Groups Env Check started"
+        $XDDeliveryGroups = Get-BrokerDesktopGroup -AdminAddress $AdminAddress
+
+        foreach ( $DeliveryGroup in $XDDeliveryGroups ) {
+            $Status = "Passed"
+            Write-Verbose "Initialize Test Variables"
+            Write-Verbose "Testing $($DeliveryGroup.Name)"
+            $TestTarget = New-EnvTestDiscoveryTargetDefinition -AdminAddress $AdminAddress -TargetIdType "DesktopGroup" -TestSuiteId "DesktopGroup" -TargetId $DeliveryGroup.Uuid
+            $TestResults = Start-EnvTestTask -AdminAddress $AdminAddress -InputObject $TestTarget -RunAsynchronously
+
+            foreach ( $Result in $TestResults.TestResults ) {
+                foreach ( $Component in $Result.TestComponents ) {
+                    Write-Verbose "$($DeliveryGroup.Name) - $($Component.TestID) - $($Component.TestComponentStatus)"
+                    if ( $Component.TestComponentStatus -ne "CompletePassed" -and ($Component.TestComponentStatus -ne "NotRun") ) {
+                        "$(DeliveryGroup.Name) - $($Component.TestID) - $($Component.TestComponentStatus)`n" | Out-File $ErrorFile -Append
+                        $Status = "Component Failure"
+                    }
+                }
+            }
+            if ( $Status -eq "Passed" ) { $EnvCheckUp++ }
+            else { $EnvCheckDown++ }
+        }
+    }
+
+    if ($CatalogCheck -eq "yes") {
+        Write-Verbose "Catalog Env Check started"
+        $XDCatalogs = Get-BrokerCatalog -AdminAddress $AdminAddress 
+
+        foreach ( $Catalog in $XDCatalogs ) {
+            $Status = "Passed"
+            Write-Verbose "Initialize Test Variables"
+            Write-Verbose "Testing $($Catalog.Name)"
+            $TestTarget = New-EnvTestDiscoveryTargetDefinition -AdminAddress $AdminAddress -TargetIdType "Catalog" -TestSuiteId "Catalog" -TargetId $Catalog.Uuid
+            $TestResults = Start-EnvTestTask -AdminAddress $AdminAddress -InputObject $TestTarget -RunAsynchronously
+            foreach ( $Result in $TestResults.TestResults ) {
+                foreach ( $Component in $Result.TestComponents ) {
+                    Write-Verbose "$Catalog.Name - $($Component.TestID) - $($Component.TestComponentStatus)"
+                    if ( ($Component.TestComponentStatus -ne "CompletePassed") -and ($Component.TestComponentStatus -ne "NotRun") ) {
+                        "$Catalog.Name - $($Component.TestID) - $($Component.TestComponentStatus)" | Out-file $ErrorFile -append
+                        $Status = "Component Failure"
+                    }
+                }            
+            }
+            if ( $Status -eq "Passed" ) { $EnvCheckUp++ }
+            else { $EnvCheckDown++ }
+        }
+    }
+
+    if ($HypervisorCheck -eq "yes") {
+        Write-Verbose "Hypervisor Env Check started"
+    
+        foreach ($Connection in $HypervisorConnections) {
+            $Status = "Passed"
+            Write-Verbose "Initialize Test Variables"
+            Write-Verbose "Testing $($Connection.Name)"
+
+            $TestTarget = New-EnvTestDiscoveryTargetDefinition -AdminAddress $AdminAddress -TargetIdType "HypervisorConnection" -TestSuiteId "HypervisorConnection" -TargetId $Connection.HypHypervisorConnectionUid
+            $TestResults = Start-EnvTestTask -AdminAddress $AdminAddress -InputObject $TestTarget -RunAsynchronously 
+            foreach ( $Result in $TestResults.TestResults ) {
+                foreach ( $Component in $Result.TestComponents ) {
+                    Write-Verbose "$($Connection.Name) - $($Component.TestID) - $($Component.TestComponentStatus)"
+                    if ( ($Component.TestComponentStatus -ne "CompletePassed") -and ($Component.TestComponentStatus -ne "NotRun") ) {
+                        "$($Connection.Name) - $($Component.TestID) - $($Component.TestComponentStatus)" | Out-file $ErrorFile -Append
+                        $Status = "Component Failure"
+                    }
+                }
+
+            }       
+            if ( $Status -eq "Passed" ) { $EnvCheckUp++ }
+            else { $EnvCheckDown++ }
+        
+            Write-Verbose "Testing associated resources"
+
+            #$HypervisorResources = Get-ProvTask -AdminAddress $AdminAddress | select HostingUnitName, HostingUnitUid -Unique | where HostingUnitName -notlike ""
+            $HypervisorResources = Get-ChildItem XDHyp:\HostingUnits\* -AdminAddress $AdminAddress | Where-Object HypervisorConnection -like $Connection.Name
+
+            # Check the resources
+            foreach ($Resource in $HypervisorResources ) {
+                $Status = "Passed"
+                $TestTarget = New-EnvTestDiscoveryTargetDefinition -AdminAddress $AdminAddress -TargetIdType "HostingUnit" -TestSuiteId "HostingUnit" -TargetId $Resource.HostingUnitUid
+                $TestResults = Start-EnvTestTask -AdminAddress $AdminAddress -InputObject $TestTarget -RunAsynchronously 
+                foreach ( $Result in $TestResults.TestResults ) {
+                    Write-Verbose "$($Connection.Name) - $($Resource.HostingUnitName) - $($Component.TestID) - $($Component.TestComponentStatus)"
+                    foreach ( $Component in $Result.TestComponents ) {
+                        if ( ($Component.TestComponentStatus -ne "CompletePassed") -and ($Component.TestComponentStatus -ne "NotRun") ) {
+                            "$($Connection.Name) - $($Resource.HostingUnitName) - $($Component.TestID) - $($Component.TestComponentStatus)`n" | Outfile $ErrorFile -append   
+                            $Status = "Component Failure"
+                        }
+                    }
+                }
+                if ( $Status -eq "Passed" ) { $EnvCheckUp++ }
+                else { $EnvCheckDown++ }
+            }
+        }
+    }
+
+    Write-Verbose "Writing EnvCheck Data to output file"
+    "envcheck-xd,$EnvCheckUp,$EnvCheckDown" | Out-File $OutputFile
+}
+
+
+
+
+
+
+
+
+
+
+}

--- a/PSGallery/Private/Test-EnvChecksXD.ps1
+++ b/PSGallery/Private/Test-EnvChecksXD.ps1
@@ -1,4 +1,4 @@
-function Test-EnvChecks-XD.ps1 {
+function Test-EnvChecksXD {
     <#   
 .SYNOPSIS   
     Checks the Status of the Environmental Tests Passed In

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -155,6 +155,12 @@
         $FASPort = $MyJSONConfigFile.Citrix.FAS.FASPort
         $FASServices = $MyJSONConfigFile.Citrix.FAS.FASServices
 
+        $TestEnvChecksXD = $MyJSONConfigFile.Citrix.EnvChecks.test
+        $EnvChecksXDCheckddc = $MyJSONConfigFile.Citrix.EnvChecks.ddccheck
+        $EnvChecksXDCheckdeliverygroup = $MyJSONConfigFile.Citrix.EnvChecks.deliverygroupcheck
+        $EnvChecksXDCheckcatalog = $MyJSONConfigFile.Citrix.EnvChecks.catalogcheck
+        $EnvChecksXDHypervisor = $MyJSONConfigFile.Citrix.EnvChecks.hypervisorcheck
+
         # Build HTML Output and Error File Full Path
         $ServerErrorFileFullPath = Join-Path -Path $OutputLocation -ChildPath $ServerErrorFile
         $DesktopErrorFileFullPath = Join-Path -Path $OutputLocation -ChildPath $DesktopErrorFile
@@ -794,7 +800,37 @@
             remove-item $FASServerData -Force
             Write-Verbose "Deleted Donut Data File $FASServerData"
         }
-  
+
+        # This needs to be in place when the Test-CC is fully enabled
+        #if ( ($TestEnvChecksXD -eq "yes") -and ($Broker -notmatch $CCServers)) {
+        if ($TestEnvChecksXD -eq "yes") {
+            # Increment Infrastructure Components
+            $InfrastructureComponents++
+            $InfrastructureList += "EnvChecks-XD"
+
+            Write-Verbose "Citrix Environmental Checks Testing enabled"
+            Write-Verbose "Building EnvCheck Data Output Files"
+            $EnvChecksXDData = Join-Path -Path $OutputLocation -ChildPath "envcheckxd-data.txt"
+
+            # Build Donut File Paths for Federated Authentication Server
+            $EnvCheckXDDonut = Join-Path -Path $OutputLocation -ChildPath "envcheckxd.html"
+
+            # Remove Existing Data Files
+            if (test-path $EnvCheckXDData) {
+                Remove-Item $EnvCheckXDData 
+            }
+
+            # Test the Federated Authentication Server Infrastructure
+            Test-EnvChecksXD $Broker $InfraErrorFileFullPath $EnvCheckXDData $EnvChecksXDCheckddc $EnvChecksXDCheckdeliverygroup $EnvChecksXDCheckcatalog $EnvChecksXDHypervisor
+
+            Write-Verbose "Building Donut Files for Citrix Environmental Checks"
+            New-Donut $EnvCheckXDDonut $EnvCheckXDData $InfraDonutSize $InfraDonutSize $UpColour $DownColour $InfraDonutStroke "EnvChecks-XD"
+
+            # Removing Donut Data File
+            remove-item $EnvChecksXDData -Force
+            Write-Verbose "Deleted Donut Data File $EnvChecksXDData"
+        }
+
         # Build the HTML output file
         New-HTMLReport $HTMLOutput $OutputLocation $InfrastructureComponents $InfrastructureList $WorkLoads $CSSFile $RefreshDuration
 

--- a/PSGallery/Public/Start-XDMonitor.ps1
+++ b/PSGallery/Public/Start-XDMonitor.ps1
@@ -839,7 +839,6 @@
         }
         
         if ( ($TestEnvChecksXD -eq "yes") -and ($TestCC -eq "no")) {
-            #if ($TestEnvChecksXD -eq "yes") {
             # Increment Infrastructure Components
             $InfrastructureComponents++
             $InfrastructureList += "EnvChecks-XD"
@@ -848,7 +847,7 @@
             Write-Verbose "Building EnvCheck Data Output Files"
             $EnvChecksXDData = Join-Path -Path $OutputLocation -ChildPath "envcheckxd-data.txt"
 
-            # Build Donut File Paths for Federated Authentication Server
+            # Build Donut File Paths for Citrix Environmental Checks
             $EnvCheckXDDonut = Join-Path -Path $OutputLocation -ChildPath "envcheckxd.html"
 
             # Remove Existing Data Files
@@ -856,7 +855,7 @@
                 Remove-Item $EnvCheckXDData 
             }
 
-            # Test the Federated Authentication Server Infrastructure
+            # Test the Citrix Environmental Checks
             Test-EnvChecksXD $Broker $InfraErrorFileFullPath $EnvCheckXDData $EnvChecksXDCheckddc $EnvChecksXDCheckdeliverygroup $EnvChecksXDCheckcatalog $EnvChecksXDHypervisor
 
             Write-Verbose "Building Donut Files for Citrix Environmental Checks"

--- a/Package/euc-monitoring-json-ref.txt
+++ b/Package/euc-monitoring-json-ref.txt
@@ -79,6 +79,13 @@
     "ProvisioningServerPort": "54321", - Provisioning Server Default Server Port 
     "ProvisioningServerServices": "BNPXE,BNTFTP,PvsApi,PVSTSB,soapserver,StreamService" - List of Services to test. See bottom of file Service reference list
     }
+    "EnvChecks": {
+        "test": "yes", - yes/no - Environment Checks, will not run if preferred Broker is Cloud Controller
+        "ddccheck": "yes", - yes/no - Delivery Controller Environment checks
+        "deliverygroupcheck": "yes" - yes/no - Delivery Group Environment Checks
+        "catalogcheck": "yes"- yes/no - Catalog Environment checks
+        "hypervisorcheck": "yes" - yes/no - Hypervisor Environment checks
+    }
 }
 
 Service reference List

--- a/Package/euc-monitoring.json.template
+++ b/Package/euc-monitoring.json.template
@@ -102,5 +102,12 @@
             "FASPort": "135",
             "FASServices": "CitrixFederatedAuthenticationService"
         }
+        "EnvChecks": {
+            "test": "yes",
+            "ddccheck": "yes",
+            "deliverygroupcheck": "yes"
+            "catalogcheck": "yes"
+            "hypervisorcheck": "yes"
+        }
     }
 }

--- a/Package/euc-monitoring.json.template
+++ b/Package/euc-monitoring.json.template
@@ -111,8 +111,8 @@
         "EnvChecks": {
             "test": "yes",
             "ddccheck": "yes",
-            "deliverygroupcheck": "yes"
-            "catalogcheck": "yes"
+            "deliverygroupcheck": "yes",
+            "catalogcheck": "yes",
             "hypervisorcheck": "yes"
         }
     }


### PR DESCRIPTION
It looks like a large part of the diff in the Start-XDMonitor is due to my editor updating the Test-CC code to have the same tab stops as the rest of the file.   Should now conform to the inplace Appveyor rules.  