### PR TITLE
v2 0 2 - feature add

### DIFF
--- a/PSGallery/Private/Get-DonutHTML.ps1
+++ b/PSGallery/Private/Get-DonutHTML.ps1
@@ -27,6 +27,7 @@ function Get-DonutHTML {
     Name                    Version         Date                Change Detail
     David Brett             1.0             07/02/2018          Function Creation
     Adam Yarborough         1.1             12/06/2018          Change to return string
+    Alex Spicola            1.6             26/08/2018          Added workload donut XD site name label
 .EXAMPLE
     None Required
 #>
@@ -40,6 +41,7 @@ function Get-DonutHTML {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DonutGoodColour,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DonutBadColour,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DonutStroke,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SiteName,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SeriesName,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SeriesUpCount,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SeriesDownCount,
@@ -63,15 +65,18 @@ function Get-DonutHTML {
         
     if ( $Worker ) {
         $HTML += "<g class='worker-chart-text'>" 
-        $HTML += "<text x='50%' y='50%' class='worker-chart-label'>" 
+        $HTML += "<text x='50%' y='50%' class='worker-chart-label'>"
+        $HTML += "$SiteName $SeriesName" 
+        $HTML += "</text>"
     }
     else {
         $HTML += "<g class='chart-text'>" 
-        $HTML += "<text x='50%' y='50%' class='chart-label'>"      
+        $HTML += "<text x='50%' y='50%' class='chart-label'>"
+        $HTML += "$SeriesName" 
+        $HTML += "</text>"      
     }
         
-    $HTML += "$SeriesName" 
-    $HTML += "</text>"
+    
     $HTML += "</g>"
     $HTML += "</svg>" 
 

--- a/PSGallery/Private/Install-VisualizationSetup.ps1
+++ b/PSGallery/Private/Install-VisualizationSetup.ps1
@@ -73,7 +73,7 @@ function Install-VisualizationSetup {
             "WEM-Details.json",
             "XDController-Details.json",
             "XDLicensing-Details.json",
-            "XenServer-Details.json"
+            "Xenserver-Details.json"
         )
 
         # Get the dashboard config.
@@ -84,7 +84,7 @@ function Install-VisualizationSetup {
             New-Item $DashboardConfig -ItemType Directory
             Write-Verbose "EUC Monitoring Dashboard Directory Created $DashboardConfig"
         }
-        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/v2_beta/DashboardConfig/DataSource.json" -OutFile $dashDatasource
+        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/master/DashboardConfig/DataSource.json" -OutFile $dashDatasource
 
         #Get the current dashboards
         if ( test-path "$DashboardConfig\Dashboards" ) {
@@ -96,7 +96,7 @@ function Install-VisualizationSetup {
         }
         foreach ($board in $Dashboards) {
             Write-Verbose "Getting Dashboard: $board"
-            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/v2_beta/DashboardConfig/Dashboards/$board" -OutFile "$DashboardConfig\Dashboards\$board"
+            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/master/DashboardConfig/Dashboards/$board" -OutFile "$DashboardConfig\Dashboards\$board"
         }
 
         #open FW for Grafana
@@ -210,7 +210,7 @@ function Install-VisualizationSetup {
 
         Write-Verbose "Downloading helper script."
         # Download the helper script
-        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/v2_beta/DashboardConfig/Begin-EUCMonitor.ps1" -OutFile "$MonitoringPath\Begin-EUCMonitor.ps1"
+        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/master/DashboardConfig/Begin-EUCMonitor.ps1" -OutFile "$MonitoringPath\Begin-EUCMonitor.ps1"
 
         Write-Output "NOTE: Grafana and Influx are now installed as services.  You might need to set their startup type to"
         Write-Output "automatic if you plan on using this long term.`n"

--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -23,6 +23,7 @@ function New-HtmlReport {
                                                                 Fixes #24
                                                                 Fixes #40
     David Brett             1.5             21/08/2018          Bug fixes and naming clean up
+    Alex Spicola            1.6             26/08/2018          Added workload donut XD site name label
 .EXAMPLE
     None Required
 #> 
@@ -125,6 +126,7 @@ function New-HtmlReport {
         $Width = $Height
         $Up = 0
         $Down = 0
+        $SiteName = "" # Blank XD site name, not used for these donuts
         $Series = $SeriesResult.Series
         if ($null -ne $series) {
             if ( "Worker" -ne $Series ) {
@@ -144,7 +146,7 @@ function New-HtmlReport {
                     "NetScaler" {$NewSeries = "Citrix ADC"; break}
                     default {$NewSeries = $Series; break}
                 }
-                Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $NewSeries $Up $Down | Out-File $HTMLOutputFileFull -Append
+                Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewSeries $Up $Down | Out-File $HTMLOutputFileFull -Append
                 "</td>" | Out-File $HTMLOutputFileFull -Append
             }
         }
@@ -172,6 +174,7 @@ function New-HtmlReport {
     foreach ($SeriesResult in $Results) { 
         $DonutStroke = $ConfigObject.Global.WebData.WorkerDonutStroke
         $Height = $ConfigObject.Global.WebData.WorkerDonutSize
+        $ShowSiteName = $ConfigObject.Global.WebData.WorkerSiteName
         $Width = $Height
         $Series = $SeriesResult.Series
 
@@ -189,7 +192,13 @@ function New-HtmlReport {
                             default {$NewName = $Series; break}
                         }
                         "<td width='$ColumnPercent%' align=center valign=top>" | Out-File $HTMLOutputFileFull -Append
-                        Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
+                        if ($ShowSiteName -eq $true) {
+                            $SiteName = $CheckData.Values.SiteName | select -Unique
+                            Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
+                        } else {
+                            $SiteName = ""
+                            Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
+                        }
                         "</td>" | Out-File $HTMLOutputFileFull -Append
                     }
                 }

--- a/PSGallery/Public/Set-EUCMonitoring.ps1
+++ b/PSGallery/Public/Set-EUCMonitoring.ps1
@@ -66,7 +66,7 @@
         }
         else {
             Write-Verbose "Pulling $needed"
-            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/eucmonitoring/v2_beta/Package/$needed" -OutFile "$MonitoringPath\$needed"
+            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/eucmonitoring/master/Package/$needed" -OutFile "$MonitoringPath\$needed"
         }
     }
 

--- a/Package/euc-monitoring-json-ref.txt
+++ b/Package/euc-monitoring-json-ref.txt
@@ -15,6 +15,7 @@
             "htmldatafile": "htmldata.txt", - Can leave as default
             "htmloutputfile": "index.html", - HTML Output File. can leave as default
             "refreshduration": 0, - HTML Automatic page refresh, in seconds. 0 for no refresh
+			"WorkerSiteName": true, - Display XD site name in server and desktkop worker donuts
             "UpColour": "rgba(221, 70, 70, 0.9)", - Color for Up Servers
             "DownColour": "rgba(67, 137, 203, 0.95)", - Color for Down Servers. 
             "WorkerDonutStroke": 5, - Width for the Worker Donut Ring

--- a/Package/euc-monitoring.json.template
+++ b/Package/euc-monitoring.json.template
@@ -15,6 +15,7 @@
             "htmldatafile": "htmldata.txt",
             "htmloutputfile": "index.html",
             "refreshduration": 0,
+			"WorkerSiteName": true,
             "UpColour": "rgba(221, 70, 70, 0.9)",
             "DownColour": "rgba(67, 137, 203, 0.95)",
             "WorkerDonutStroke": 5,


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Added option to include XD site name in server and desktop worker donuts. This is an option that can be selected by the user in the JSON file. Update JSON template, JSON reference. Scripts edited to allow this were New-HtmlReport.ps1 and Get-DonutHTML.ps1.

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [X] Feature 1
- Worker donut site name display
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

When monitoring multiple sites the worker donuts did not specify what site they were. This was slightly confusing.

Does the code pass AppVeyor?
* [ ] Yes

@dbretty not sure how to run this?

<!-- Make sure tests pass on AppVeyor before submitting. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #