### PR TITLE
v 2 0 2 - feature add - worker donut site name

### DIFF
--- a/PSGallery/Private/Install-VisualizationSetup.ps1
+++ b/PSGallery/Private/Install-VisualizationSetup.ps1
@@ -73,7 +73,7 @@ function Install-VisualizationSetup {
             "WEM-Details.json",
             "XDController-Details.json",
             "XDLicensing-Details.json",
-            "XenServer-Details.json"
+            "Xenserver-Details.json"
         )
 
         # Get the dashboard config.
@@ -84,7 +84,7 @@ function Install-VisualizationSetup {
             New-Item $DashboardConfig -ItemType Directory
             Write-Verbose "EUC Monitoring Dashboard Directory Created $DashboardConfig"
         }
-        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/v2_beta/DashboardConfig/DataSource.json" -OutFile $dashDatasource
+        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/master/DashboardConfig/DataSource.json" -OutFile $dashDatasource
 
         #Get the current dashboards
         if ( test-path "$DashboardConfig\Dashboards" ) {
@@ -96,7 +96,7 @@ function Install-VisualizationSetup {
         }
         foreach ($board in $Dashboards) {
             Write-Verbose "Getting Dashboard: $board"
-            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/v2_beta/DashboardConfig/Dashboards/$board" -OutFile "$DashboardConfig\Dashboards\$board"
+            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/master/DashboardConfig/Dashboards/$board" -OutFile "$DashboardConfig\Dashboards\$board"
         }
 
         #open FW for Grafana
@@ -210,7 +210,7 @@ function Install-VisualizationSetup {
 
         Write-Verbose "Downloading helper script."
         # Download the helper script
-        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/v2_beta/DashboardConfig/Begin-EUCMonitor.ps1" -OutFile "$MonitoringPath\Begin-EUCMonitor.ps1"
+        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/EUCMonitoring/master/DashboardConfig/Begin-EUCMonitor.ps1" -OutFile "$MonitoringPath\Begin-EUCMonitor.ps1"
 
         Write-Output "NOTE: Grafana and Influx are now installed as services.  You might need to set their startup type to"
         Write-Output "automatic if you plan on using this long term.`n"

--- a/PSGallery/Public/Set-EUCMonitoring.ps1
+++ b/PSGallery/Public/Set-EUCMonitoring.ps1
@@ -66,7 +66,7 @@
         }
         else {
             Write-Verbose "Pulling $needed"
-            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/eucmonitoring/v2_beta/Package/$needed" -OutFile "$MonitoringPath\$needed"
+            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dbretty/eucmonitoring/master/Package/$needed" -OutFile "$MonitoringPath\$needed"
         }
     }
 


### PR DESCRIPTION
Still pulling resources from the v2_beta.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Adding XD site name to server and desktop worker donuts. This will be optional based on the user changing the option in the JSON file.

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [x] Worker donut site labels
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Monitoring multiple sites did not show any labels as to which worker donuts were for which site. This was confusing.

Does the code pass AppVeyor?
* [x] Yes

<!-- Make sure tests pass on AppVeyor before submitting. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #