### PR TITLE
Worker site name & column width bug fix

### DIFF
--- a/PSGallery/Private/Get-DonutHTML.ps1
+++ b/PSGallery/Private/Get-DonutHTML.ps1
@@ -27,6 +27,7 @@ function Get-DonutHTML {
     Name                    Version         Date                Change Detail
     David Brett             1.0             07/02/2018          Function Creation
     Adam Yarborough         1.1             12/06/2018          Change to return string
+    Alex Spicola            1.2             11/09/2018          Worker donut site name
 .EXAMPLE
     None Required
 #>
@@ -40,6 +41,7 @@ function Get-DonutHTML {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DonutGoodColour,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DonutBadColour,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$DonutStroke,
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SiteName,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SeriesName,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SeriesUpCount,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]$SeriesDownCount,
@@ -62,12 +64,14 @@ function Get-DonutHTML {
     $HTML += "<circle class='donut-segment' cx='21' cy='21' r='15.91549430918954' fill='transparent' stroke='$DonutBadColour' stroke-width='$DonutStroke' stroke-dasharray='$SeriesUpCount $SeriesDownCount' stroke-dashoffset='25'></circle>" 
         
     if ( $Worker ) {
-        $HTML += "<g class='worker-chart-text'>" 
-        $HTML += "<text x='50%' y='50%' class='worker-chart-label'>" 
+         $HTML += "<g class='worker-chart-text'>" 
+        $HTML += "<text x='50%' y='50%' class='worker-chart-label'>"
+        $HTML += "$SiteName $SeriesName" 
+        $HTML += "</text>"
     }
     else {
         $HTML += "<g class='chart-text'>" 
-        $HTML += "<text x='50%' y='50%' class='chart-label'>"      
+        $HTML += "<text x='50%' y='50%' class='chart-label'>"    
     }
         
     $HTML += "$SeriesName" 

--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -22,7 +22,8 @@ function New-HtmlReport {
     David Brett             1.4             26/06/2018          Bug Fixes and Code Cleaning
                                                                 Fixes #24
                                                                 Fixes #40
-    David Brett             1.5             21/08/2018          Bug fixes and naming clean up
+    David Brett             1.5             21/08/2018          Bug fixes and naming clean 
+    Alex Spicola            1.7             11/09/2018          Worker donut site name, bug fixes
 .EXAMPLE
     None Required
 #> 
@@ -116,7 +117,7 @@ function New-HtmlReport {
             $totalinf ++
         }
     } 
-    $totalinf--
+    if ($TotalInf -gt 1) {$totalinf--} 
     $ColumnPercent = 100 / [int]$totalinf
 
     foreach ($SeriesResult in $Results) { 
@@ -125,6 +126,7 @@ function New-HtmlReport {
         $Width = $Height
         $Up = 0
         $Down = 0
+        $SiteName = "" # Blank XD site name, not used for these donuts
         $Series = $SeriesResult.Series
         if ($null -ne $series) {
             if ( "Worker" -ne $Series ) {
@@ -144,7 +146,7 @@ function New-HtmlReport {
                     "NetScaler" {$NewSeries = "Citrix ADC"; break}
                     default {$NewSeries = $Series; break}
                 }
-                Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $NewSeries $Up $Down | Out-File $HTMLOutputFileFull -Append
+                Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewSeries $Up $Down | Out-File $HTMLOutputFileFull -Append
                 "</td>" | Out-File $HTMLOutputFileFull -Append
             }
         }
@@ -172,6 +174,7 @@ function New-HtmlReport {
     foreach ($SeriesResult in $Results) { 
         $DonutStroke = $ConfigObject.Global.WebData.WorkerDonutStroke
         $Height = $ConfigObject.Global.WebData.WorkerDonutSize
+        $ShowSiteName = $ConfigObject.Global.WebData.WorkerSiteName
         $Width = $Height
         $Series = $SeriesResult.Series
 
@@ -189,7 +192,13 @@ function New-HtmlReport {
                             default {$NewName = $Series; break}
                         }
                         "<td width='$ColumnPercent%' align=center valign=top>" | Out-File $HTMLOutputFileFull -Append
-                        Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
+                        if ($ShowSiteName -eq $true) {
+                            $SiteName = $CheckData.Values.SiteName | select -Unique
+                            Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
+                        } else {
+                            $SiteName = ""
+                            Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
+                        }
                         "</td>" | Out-File $HTMLOutputFileFull -Append
                     }
                 }

--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -193,7 +193,7 @@ function New-HtmlReport {
                         }
                         "<td width='$ColumnPercent%' align=center valign=top>" | Out-File $HTMLOutputFileFull -Append
                         if ($ShowSiteName -eq $true) {
-                            $SiteName = $CheckData.Values.SiteName | select -Unique
+                            $SiteName = $CheckData.Values.SiteName | Select-Object -Unique
                             Get-DonutHTML $Height $Width $UpColor $DownColor $DonutStroke $SiteName $NewName $Up $Down -Worker | Out-File $HTMLOutputFileFull -Append
                         } else {
                             $SiteName = ""

--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -23,7 +23,7 @@ function New-HtmlReport {
                                                                 Fixes #24
                                                                 Fixes #40
     David Brett             1.5             21/08/2018          Bug fixes and naming clean 
-    Alex Spicola            1.7             11/09/2018          Worker donut site name, bug fixes
+    Alex Spicola            1.6             11/09/2018          Worker donut site name, bug fixes
 .EXAMPLE
     None Required
 #> 

--- a/PSGallery/Private/New-HtmlReport.ps1
+++ b/PSGallery/Private/New-HtmlReport.ps1
@@ -115,9 +115,9 @@ function New-HtmlReport {
     foreach ($SeriesResult in $Results) {
         if ("Worker" -ne $seriesresult.series) {
             $totalinf ++
-        }
+        } 
     } 
-    if ($TotalInf -gt 1) {$totalinf--} 
+    if ($TotalInf -gt 1) {$totalinf--} else {$TotalInf = 1}
     $ColumnPercent = 100 / [int]$totalinf
 
     foreach ($SeriesResult in $Results) { 

--- a/Package/euc-monitoring-json-ref.txt
+++ b/Package/euc-monitoring-json-ref.txt
@@ -15,7 +15,7 @@
             "htmldatafile": "htmldata.txt", - Can leave as default
             "htmloutputfile": "index.html", - HTML Output File. can leave as default
             "refreshduration": 0, - HTML Automatic page refresh, in seconds. 0 for no refresh
-	    "WorkerSiteName": false, - Display XD site name in server and desktkop worker donuts
+            "WorkerSiteName": false, - Display XD site name in server and desktkop worker donuts
             "UpColour": "rgba(221, 70, 70, 0.9)", - Color for Up Servers
             "DownColour": "rgba(67, 137, 203, 0.95)", - Color for Down Servers. 
             "WorkerDonutStroke": 5, - Width for the Worker Donut Ring

--- a/Package/euc-monitoring-json-ref.txt
+++ b/Package/euc-monitoring-json-ref.txt
@@ -15,6 +15,7 @@
             "htmldatafile": "htmldata.txt", - Can leave as default
             "htmloutputfile": "index.html", - HTML Output File. can leave as default
             "refreshduration": 0, - HTML Automatic page refresh, in seconds. 0 for no refresh
+			"WorkerSiteName": false, - Display XD site name in server and desktkop worker donuts
             "UpColour": "rgba(221, 70, 70, 0.9)", - Color for Up Servers
             "DownColour": "rgba(67, 137, 203, 0.95)", - Color for Down Servers. 
             "WorkerDonutStroke": 5, - Width for the Worker Donut Ring

--- a/Package/euc-monitoring-json-ref.txt
+++ b/Package/euc-monitoring-json-ref.txt
@@ -15,7 +15,7 @@
             "htmldatafile": "htmldata.txt", - Can leave as default
             "htmloutputfile": "index.html", - HTML Output File. can leave as default
             "refreshduration": 0, - HTML Automatic page refresh, in seconds. 0 for no refresh
-			"WorkerSiteName": false, - Display XD site name in server and desktkop worker donuts
+	    "WorkerSiteName": false, - Display XD site name in server and desktkop worker donuts
             "UpColour": "rgba(221, 70, 70, 0.9)", - Color for Up Servers
             "DownColour": "rgba(67, 137, 203, 0.95)", - Color for Down Servers. 
             "WorkerDonutStroke": 5, - Width for the Worker Donut Ring

--- a/Package/euc-monitoring.json.template
+++ b/Package/euc-monitoring.json.template
@@ -15,7 +15,7 @@
             "htmldatafile": "htmldata.txt",
             "htmloutputfile": "index.html",
             "refreshduration": 0,
-			"WorkerSiteName": false,
+	    "WorkerSiteName": false,
             "UpColour": "rgba(221, 70, 70, 0.9)",
             "DownColour": "rgba(67, 137, 203, 0.95)",
             "WorkerDonutStroke": 5,

--- a/Package/euc-monitoring.json.template
+++ b/Package/euc-monitoring.json.template
@@ -15,6 +15,7 @@
             "htmldatafile": "htmldata.txt",
             "htmloutputfile": "index.html",
             "refreshduration": 0,
+			"WorkerSiteName": false,
             "UpColour": "rgba(221, 70, 70, 0.9)",
             "DownColour": "rgba(67, 137, 203, 0.95)",
             "WorkerDonutStroke": 5,


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

**Summary**

Enabled worker donut site names as an option. Can be used when monitoring multiple sites from the same JSON. Fixed a bug for the column width for infra donuts where it was trying to divide by 0.

This PR fixes/implements the following **bugs/features**

* [X] Divide by 0 issue for column width
* [ ] Bug 2
* [X] Worker donut site name
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

When monitoring multiple sites you could not tell which worker donut was for which site. Enabling the site name for each worker donut allows admins to see this information on the web output.

Does the code pass AppVeyor?
* [x] Yes

<!-- Make sure tests pass on AppVeyor before submitting. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #